### PR TITLE
AND/Mixed keyword matching logic + minor bug fix

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,20 +2,21 @@ from scraper import Scraper
 from extract import Extractor
 from filters import title_filter, keywords_filter, abstract_filter
 from selector import Selector
-from utils import save_papers, load_papers
+from utils import *
+import os
 
 
-years = list(map(str, range(2024, 2026)))
+years = list(map(str, range(2025, 2026)))
 
 conferences = [
     "ICLR",
-    'ICML',
-    "EMNLP",
-    'ACL',
-    "arXiv",
+    # "ICML",
+    # "EMNLP",
+    # "ACL",
+    # "arXiv",
 ]
 
-# AND outside, OR inside 
+# AND outside, OR inside
 # Example: ["a", ["b", "c"], "d"] means: (a) AND (b OR c) AND (d)
 keywords = [
     ["Large Language Model", "LLM"],
@@ -25,24 +26,49 @@ keywords = [
 
 
 def modify_paper(paper):
-    paper.forum = f"https://openreview.net/forum?id={paper.forum}"
-    paper.content["pdf"] = f"https://openreview.net{paper.content['pdf']}"
+    forum_id = paper.forum
+    paper.forum = f"https://openreview.net/forum?id={forum_id}"
+    pdf_url = f"https://openreview.net{unwrap_value(paper.content['pdf'])}"
+    paper.content["pdf"] = pdf_url
+    # Download PDF
+    pdf_filename = f"{forum_id}.pdf"
+    pdf_path = download_pdf(pdf_url, dest_folder="pdfs", filename=pdf_filename)
+    if pdf_path:
+        paper.content["pdf_local"] = os.path.abspath(pdf_path)
+    else:
+        paper.content["pdf_local"] = ""
+    # Fetch BibTeX only for filtered/selected papers
+    paper.content["bibtex"] = fetch_bibtex_from_data_bibtex(forum_id)
     return paper
 
 
 extractor = Extractor(
     fields=["forum"],
-    subfields={"content": ["title", "keywords", "abstract", "pdf", "match"]},
+    subfields={
+        "content": [
+            "title",
+            "authors",
+            "keywords",
+            "abstract",
+            "pdf",
+            "pdf_local",
+            "match",
+            "bibtex",
+        ]
+    },
 )
+
 selector = Selector()
 scraper = Scraper(
     conferences=conferences,
     years=years,
     keywords=keywords,
     extractor=extractor,
-    fpath="example.csv",
+    fpath="/home/p3dr4m0098/HWs/NLPLAB/Scrapper/mine/openreview_scraper/example.csv",
     fns=[modify_paper],
-    selector=selector,
+    # Set to None to skip selection;
+    # use instance of Selector, i.e. selector to enable selection
+    selector=None,
     filter_mode="MIX",
 )
 

--- a/example.py
+++ b/example.py
@@ -5,24 +5,46 @@ from selector import Selector
 from utils import save_papers, load_papers
 
 
-years = [
-    '2024'
-]
+years = list(map(str, range(2024, 2026)))
+
 conferences = [
-    'ICLR'
+    "ICLR",
+    'ICML',
+    "EMNLP",
+    'ACL',
+    "arXiv",
 ]
+
+# AND outside, OR inside 
+# Example: ["a", ["b", "c"], "d"] means: (a) AND (b OR c) AND (d)
 keywords = [
-    'generalization'
+    ["Large Language Model", "LLM"],
+    ["Game Theory", "equilibrium", "Nash"],
+    ["Reinforcement Learning", "RL", "Multi-Agent"],
 ]
+
 
 def modify_paper(paper):
-  paper.forum = f"https://openreview.net/forum?id={paper.forum}"
-  paper.content['pdf'] = f"https://openreview.net{paper.content['pdf']}"
-  return paper
+    paper.forum = f"https://openreview.net/forum?id={paper.forum}"
+    paper.content["pdf"] = f"https://openreview.net{paper.content['pdf']}"
+    return paper
 
-extractor = Extractor(fields=['forum'], subfields={'content':['title', 'keywords', 'abstract', 'pdf', 'match']})
+
+extractor = Extractor(
+    fields=["forum"],
+    subfields={"content": ["title", "keywords", "abstract", "pdf", "match"]},
+)
 selector = Selector()
-scraper = Scraper(conferences=conferences, years=years, keywords=keywords, extractor=extractor, fpath='example.csv', fns=[modify_paper], selector=selector)
+scraper = Scraper(
+    conferences=conferences,
+    years=years,
+    keywords=keywords,
+    extractor=extractor,
+    fpath="example.csv",
+    fns=[modify_paper],
+    selector=selector,
+    filter_mode="MIX",
+)
 
 scraper.add_filter(title_filter)
 scraper.add_filter(keywords_filter)
@@ -30,5 +52,5 @@ scraper.add_filter(abstract_filter)
 
 scraper()
 
-save_papers(scraper.papers, fpath='papers.pkl')
-saved_papers = load_papers(fpath='papers.pkl')
+save_papers(scraper.papers, fpath="papers.pkl")
+saved_papers = load_papers(fpath="papers.pkl")

--- a/extract.py
+++ b/extract.py
@@ -7,18 +7,26 @@ class Extractor:
     def __call__(self, paper):
         return self.extract(paper)
 
+    def _unwrap_value(self, value):
+        # Unwrap {"value": ...} dicts recursively
+        if isinstance(value, dict) and set(value.keys()) == {"value"}:
+            return self._unwrap_value(value["value"])
+        return value
+
     def extract(self, paper):
         trimmed_paper = {}
         for field in self.fields:
-            trimmed_paper[field] = getattr(paper, field, None)
+            raw_value = getattr(paper, field, None)
+            trimmed_paper[field] = self._unwrap_value(raw_value)
         for subfield, fields in self.subfields.items():
             subdict = getattr(paper, subfield, {})
             if self.include_subfield:
                 trimmed_paper[subfield] = {}
             for field in fields:
                 field_value = subdict.get(field, None)
+                unwrapped_value = self._unwrap_value(field_value)
                 if self.include_subfield:
-                    trimmed_paper[subfield][field] = field_value
+                    trimmed_paper[subfield][field] = unwrapped_value
                 else:
-                    trimmed_paper[field] = field_value
+                    trimmed_paper[field] = unwrapped_value
         return trimmed_paper

--- a/extract.py
+++ b/extract.py
@@ -1,23 +1,24 @@
 class Extractor:
-  def __init__(self, fields, subfields, include_subfield=False):
-    self.fields = fields
-    self.subfields = subfields
-    self.include_subfield = include_subfield
-  
-  def __call__(self, paper):
-    return self.extract(paper)
+    def __init__(self, fields, subfields, include_subfield=False):
+        self.fields = fields
+        self.subfields = subfields
+        self.include_subfield = include_subfield
 
-  def extract(self, paper):
-    trimmed_paper = {}
-    for field in self.fields:
-      trimmed_paper[field] = paper.__getattribute__(field)
-    for subfield, fields in self.subfields.items():
-      if self.include_subfield:
-        trimmed_paper[subfield] = {}
-      for field in fields:
-        field_value = paper.__getattribute__(subfield)[field]
-        if self.include_subfield:
-          trimmed_paper[subfield][field] = field_value
-        else:
-          trimmed_paper[field] = field_value
-    return trimmed_paper
+    def __call__(self, paper):
+        return self.extract(paper)
+
+    def extract(self, paper):
+        trimmed_paper = {}
+        for field in self.fields:
+            trimmed_paper[field] = getattr(paper, field, None)
+        for subfield, fields in self.subfields.items():
+            subdict = getattr(paper, subfield, {})
+            if self.include_subfield:
+                trimmed_paper[subfield] = {}
+            for field in fields:
+                field_value = subdict.get(field, None)
+                if self.include_subfield:
+                    trimmed_paper[subfield][field] = field_value
+                else:
+                    trimmed_paper[field] = field_value
+        return trimmed_paper

--- a/filters.py
+++ b/filters.py
@@ -2,102 +2,157 @@ from thefuzz import fuzz
 
 
 def check_keywords_with_keywords(keywords, paper_keywords, threshold):
-  if not paper_keywords:
+    if not paper_keywords:
+        return None, False
+
+    # Ensure paper_keywords is a list
+    if not isinstance(paper_keywords, list):
+        if isinstance(paper_keywords, str):
+            paper_keywords = [paper_keywords]
+        else:
+            try:
+                paper_keywords = list(paper_keywords)
+            except:
+                paper_keywords = [str(paper_keywords)]
+
+    for keyword in keywords:
+        if keyword is None:
+            continue
+
+        # Ensure keyword is a string
+        keyword = str(keyword)
+
+        if not keyword.strip():
+            continue
+
+        for paper_keyword in paper_keywords:
+            if paper_keyword is None:
+                continue
+
+            # Ensure paper_keyword is a string
+            paper_keyword = str(paper_keyword)
+
+            if not paper_keyword.strip():
+                continue
+
+            try:
+                if fuzz.ratio(keyword, paper_keyword) >= threshold:
+                    return keyword, True
+            except Exception as e:
+                print(f"Error comparing '{keyword}' with '{paper_keyword}': {e}")
+                continue
+
     return None, False
-    
-  # Ensure paper_keywords is a list
-  if not isinstance(paper_keywords, list):
-    if isinstance(paper_keywords, str):
-      paper_keywords = [paper_keywords]
-    else:
-      try:
-        paper_keywords = list(paper_keywords)
-      except:
-        paper_keywords = [str(paper_keywords)]
-  
-  for keyword in keywords:
-    if keyword is None:
-      continue
-      
-    # Ensure keyword is a string
-    keyword = str(keyword)
-    
-    if not keyword.strip():
-      continue
-      
-    for paper_keyword in paper_keywords:
-      if paper_keyword is None:
-        continue
-        
-      # Ensure paper_keyword is a string
-      paper_keyword = str(paper_keyword)
-      
-      if not paper_keyword.strip():
-        continue
-        
-      try:
-        if fuzz.ratio(keyword, paper_keyword) >= threshold:
-          return keyword, True
-      except Exception as e:
-        print(f"Error comparing '{keyword}' with '{paper_keyword}': {e}")
-        continue
-        
-  return None, False
 
 
 def check_keywords_with_text(keywords, text, threshold):
-  if text is None:
+    if text is None:
+        return None, False
+
+    # Ensure text is a string
+    text = str(text)
+
+    for keyword in keywords:
+        if keyword is None:
+            continue
+
+        # Ensure keyword is a string
+        keyword = str(keyword)
+
+        # Skip empty strings
+        if not keyword.strip() or not text.strip():
+            continue
+
+        try:
+            if fuzz.partial_ratio(keyword, text) >= threshold:
+                return keyword, True
+        except Exception as e:
+            print(f"Error comparing '{keyword}' with text: {e}")
+            continue
+
     return None, False
-    
-  # Ensure text is a string
-  text = str(text)
-  
-  for keyword in keywords:
-    if keyword is None:
-      continue
-      
-    # Ensure keyword is a string
-    keyword = str(keyword)
-    
-    # Skip empty strings
-    if not keyword.strip() or not text.strip():
-      continue
-      
-    try:
-      if fuzz.partial_ratio(keyword, text) >= threshold:
-        return keyword, True
-    except Exception as e:
-      print(f"Error comparing '{keyword}' with text: {e}")
-      continue
-      
-  return None, False
 
 
 def satisfies_any_filters(paper, keywords, filters):
-  for filter_, args, kwargs in filters:
-    matched_keyword, matched = filter_(paper, keywords=keywords, *args, **kwargs)
-    if matched:
-      filter_type = filter_.__name__
-      return matched_keyword, filter_type, True
-  return None, None, False
+    for filter_, args, kwargs in filters:
+        matched_keyword, matched = filter_(paper, keywords=keywords, *args, **kwargs)
+        if matched:
+            filter_type = filter_.__name__
+            return matched_keyword, filter_type, True
+    return None, None, False
+
+
+def satisfies_all_filters(paper, keywords, filters):
+    matched_keywords = []
+    filter_types = []
+    for filter_, args, kwargs in filters:
+        matched_keyword, matched = filter_(paper, keywords=keywords, *args, **kwargs)
+        if not matched:
+            return None, None, False
+        filter_types.append(filter_.__name__)
+        matched_keywords.append(matched_keyword)
+    return matched_keywords, filter_types, True
+
+
+def satisfies_mixed_filters(paper, keywords, filters):
+    """
+    keywords: list, e.g. ["a", ["b", "c"]]
+    Each element is either a string (must match) or a list (any in the list must match).
+    The outer list is AND, inner lists are OR.
+    """
+    matched_keywords = []
+    filter_types = []
+    for idx, keyword_group in enumerate(keywords):
+        if isinstance(keyword_group, list):
+            # OR logic for this group
+            group_matched = False
+            for kw in keyword_group:
+                for filter_, args, kwargs in filters:
+                    matched_keyword, matched = filter_(
+                        paper, keywords=[kw], *args, **kwargs
+                    )
+                    if matched:
+                        matched_keywords.append(matched_keyword)
+                        filter_types.append(filter_.__name__)
+                        group_matched = True
+                        break
+                if group_matched:
+                    break
+            if not group_matched:
+                return None, None, False
+        else:
+            # Single keyword, must match
+            group_matched = False
+            for filter_, args, kwargs in filters:
+                matched_keyword, matched = filter_(
+                    paper, keywords=[keyword_group], *args, **kwargs
+                )
+                if matched:
+                    matched_keywords.append(matched_keyword)
+                    filter_types.append(filter_.__name__)
+                    group_matched = True
+                    break
+            if not group_matched:
+                return None, None, False
+    return matched_keywords, filter_types, True
 
 
 def keywords_filter(paper, keywords, threshold=85):
-  paper_keywords = paper.content.get('keywords')
-  if paper_keywords is not None:
-    return check_keywords_with_keywords(keywords, paper_keywords, threshold)
-  return None, False
+    paper_keywords = paper.content.get("keywords")
+    if paper_keywords is not None:
+        return check_keywords_with_keywords(keywords, paper_keywords, threshold)
+    return None, False
 
 
 def title_filter(paper, keywords, threshold=85):
-  paper_title = paper.content.get('title')
-  if paper_title is not None:
-    return check_keywords_with_text(keywords, paper_title, threshold)
-  return None, False
+    paper_title = paper.content.get("title")
+    if paper_title is not None:
+        return check_keywords_with_text(keywords, paper_title, threshold)
+    return None, False
 
 
 def abstract_filter(paper, keywords, threshold=85):
-  paper_abstract = paper.content.get('abstract')
-  if paper_abstract is not None:
-    return check_keywords_with_text(keywords, paper_abstract, threshold)
-  return None, False
+    paper_abstract = paper.content.get("abstract")
+    if paper_abstract is not None:
+        return check_keywords_with_text(keywords, paper_abstract, threshold)
+    return None, False

--- a/paper.py
+++ b/paper.py
@@ -1,76 +1,92 @@
 def get_grouped_venue_papers(clients, grouped_venue, only_accepted):
-  """
-  Get papers from both API v1 and API v2 clients and merge the results.
-  
-  Args:
-    clients: Tuple of (client_v1, client_v2)
-    grouped_venue: List of venue IDs
-    only_accepted: Boolean to filter only accepted papers
-    
-  Returns:
-    Dictionary of papers by venue
-  """
-  client_v1, client_v2 = clients
-  papers = {}
-  
-  for venue in grouped_venue:
-    papers[venue] = []
-    
-    # Get papers from API v1
-    submissions_v1 = []
-    try:
-      if only_accepted:
-        submissions_v1 = client_v1.get_all_notes(content={'venueid': venue}, details='directReplies')
-      else:
-        single_blind_submissions = client_v1.get_all_notes(invitation=f'{venue}/-/Submission', details='directReplies')
-        double_blind_submissions = client_v1.get_all_notes(invitation=f'{venue}/-/Blind_Submission', details='directReplies')
-        submissions_v1 = single_blind_submissions + double_blind_submissions
-    except Exception as e:
-      print(f"Error getting papers from API v1 for venue {venue}: {e}")
-    
-    # Get papers from API v2
-    submissions_v2 = []
-    try:
-      if only_accepted:
-        submissions_v2 = client_v2.get_all_notes(content={'venueid': venue}, details='directReplies')
-      else:
-        single_blind_submissions = client_v2.get_all_notes(invitation=f'{venue}/-/Submission', details='directReplies')
-        double_blind_submissions = client_v2.get_all_notes(invitation=f'{venue}/-/Blind_Submission', details='directReplies')
-        submissions_v2 = single_blind_submissions + double_blind_submissions
-    except Exception as e:
-      print(f"Error getting papers from API v2 for venue {venue}: {e}")
-    
-    # Merge submissions from both APIs
-    # Use forum IDs to avoid duplicates
-    forum_ids = set()
-    merged_submissions = []
-    
-    for submission in submissions_v1 + submissions_v2:
-      if hasattr(submission, 'forum') and submission.forum not in forum_ids:
-        forum_ids.add(submission.forum)
-        merged_submissions.append(submission)
-    
-    papers[venue] += merged_submissions
-    
-    print(venue)
-    print(f'Number of papers: {len(merged_submissions)}')
-  
-  return papers
+    """
+    Get papers from both API v1 and API v2 clients and merge the results.
+
+    Args:
+      clients: Tuple of (client_v1, client_v2)
+      grouped_venue: List of venue IDs
+      only_accepted: Boolean to filter only accepted papers
+
+    Returns:
+      Dictionary of papers by venue
+    """
+    client_v1, client_v2 = clients
+    papers = {}
+
+    for venue in grouped_venue:
+        papers[venue] = []
+
+        # Get papers from API v1
+        submissions_v1 = []
+        try:
+            if only_accepted:
+                submissions_v1 = client_v1.get_all_notes(
+                    content={"venueid": venue}, details="directReplies"
+                )
+            else:
+                single_blind_submissions = client_v1.get_all_notes(
+                    invitation=f"{venue}/-/Submission", details="directReplies"
+                )
+                double_blind_submissions = client_v1.get_all_notes(
+                    invitation=f"{venue}/-/Blind_Submission", details="directReplies"
+                )
+                submissions_v1 = single_blind_submissions + double_blind_submissions
+        except Exception as e:
+            print(f"Error getting papers from API v1 for venue {venue}: {e}")
+
+        # Get papers from API v2
+        submissions_v2 = []
+        try:
+            if only_accepted:
+                submissions_v2 = client_v2.get_all_notes(
+                    content={"venueid": venue}, details="directReplies"
+                )
+            else:
+                single_blind_submissions = client_v2.get_all_notes(
+                    invitation=f"{venue}/-/Submission", details="directReplies"
+                )
+                double_blind_submissions = client_v2.get_all_notes(
+                    invitation=f"{venue}/-/Blind_Submission", details="directReplies"
+                )
+                submissions_v2 = single_blind_submissions + double_blind_submissions
+        except Exception as e:
+            print(f"Error getting papers from API v2 for venue {venue}: {e}")
+
+        # Merge submissions from both APIs
+        # Use forum IDs to avoid duplicates
+        forum_ids = set()
+        merged_submissions = []
+
+        for submission in submissions_v1 + submissions_v2:
+            if hasattr(submission, "forum") and submission.forum not in forum_ids:
+                forum_ids.add(submission.forum)
+                # Add BibTeX here
+                # Try to get venue name from venue string, fallback to "OpenReview"
+                venue_name = venue.split("/")[0] if "/" in venue else "OpenReview"
+                # submission.content["bibtex"] = fetch_bibtex_from_html(submission.forum)
+                merged_submissions.append(submission)
+
+        papers[venue] += merged_submissions
+
+        print(venue)
+        print(f"Number of papers: {len(merged_submissions)}")
+
+    return papers
 
 
 def get_papers(clients, grouped_venues, only_accepted):
-  """
-  Get papers for all grouped venues.
-  
-  Args:
-    clients: Tuple of (client_v1, client_v2)
-    grouped_venues: Dictionary of venue IDs by group
-    only_accepted: Boolean to filter only accepted papers
-    
-  Returns:
-    Dictionary of papers by group and venue
-  """
-  papers = {}
-  for group, grouped_venue in grouped_venues.items():
-    papers[group] = get_grouped_venue_papers(clients, grouped_venue, only_accepted)
-  return papers
+    """
+    Get papers for all grouped venues.
+
+    Args:
+      clients: Tuple of (client_v1, client_v2)
+      grouped_venues: Dictionary of venue IDs by group
+      only_accepted: Boolean to filter only accepted papers
+
+    Returns:
+      Dictionary of papers by group and venue
+    """
+    papers = {}
+    for group, grouped_venue in grouped_venues.items():
+        papers[group] = get_grouped_venue_papers(clients, grouped_venue, only_accepted)
+    return papers

--- a/scraper.py
+++ b/scraper.py
@@ -1,71 +1,101 @@
 from utils import get_client, to_csv, papers_to_list
 from venue import get_venues, group_venues
 from paper import get_papers
-from filters import satisfies_any_filters
+from filters import satisfies_any_filters, satisfies_all_filters, satisfies_mixed_filters
 
 
 class Scraper:
-  def __init__(self, conferences, years, keywords, extractor, fpath, selector=None, fns=[], groups=['conference'], only_accepted=True):
-    # fns is a list of functions that can be specified by the user each taking in a single paper object as a parameter and returning the modified paper
-    self.confs = conferences
-    self.years = years
-    self.keywords = keywords
-    self.extractor = extractor
-    self.fpath = fpath
-    self.fns = fns
-    self.groups = groups
-    self.only_accepted = only_accepted
-    self.selector = selector
-    self.filters = []
-    # Get both API v1 and API v2 clients
-    self.clients = get_client()
-    self.papers = None # this'll contain all the papers returned from apply_on_papers
-  
-  def __call__(self):
-    self.scrape()
-  
-  def scrape(self):
-    print("Getting venues...")
-    venues = get_venues(self.clients, self.confs, self.years)
-    print("Getting papers...\n")
-    papers = get_papers(self.clients, group_venues(venues, self.groups), self.only_accepted)
-    self.papers = papers
-    print("\nFiltering papers...")
-    papers = self.apply_on_papers(papers)
-    if self.selector is not None:
-      papers_list = self.selector(papers)
-    else:
-      papers_list = papers_to_list(papers)
-    print("Saving as CSV...")
-    to_csv(papers_list, self.fpath)
-    print(f"Saved at {self.fpath}")
-  
-  def apply_on_papers(self, papers):
-    modified_papers = {}
-    for group, grouped_venues in papers.items():
-      modified_papers[group] = {}
-      for venue, venue_papers in grouped_venues.items():
-        modified_papers[group][venue] = []
-        venue_split = venue.split('/')
-        venue_name, venue_year, venue_type = venue_split[0], venue_split[1], venue_split[2]
-        for paper in venue_papers:
-          # FILTERS
-          satisfying_keyword, satisfying_filter_type, satisfies = satisfies_any_filters(paper, self.keywords, self.filters)
-          if satisfies:
-            # creating a new field(key) in content attr which is a dict
-            paper.content['match'] = {satisfying_filter_type: satisfying_keyword}
-            paper.content['group'] = group
-            # Execute some custom functions
-            for fn in self.fns:
-              paper = fn(paper)
-            # FIELD EXTRACTION here paper object will be converted into a dict
-            extracted_paper = self.extractor(paper)
-            # add some extra fields
-            extracted_paper['venue'] = venue_name
-            extracted_paper['year'] = venue_year
-            extracted_paper['type'] = venue_type
-            modified_papers[group][venue].append(extracted_paper)
-    return modified_papers
+    def __init__(
+        self,
+        conferences,
+        years,
+        keywords,
+        extractor,
+        fpath,
+        selector=None,
+        fns=[],
+        groups=["conference"],
+        only_accepted=True,
+        filter_mode="OR",
+    ):
+        # fns is a list of functions that can be specified by the user each taking in a single paper object as a parameter and returning the modified paper
+        self.confs = conferences
+        self.years = years
+        self.keywords = keywords
+        self.extractor = extractor
+        self.fpath = fpath
+        self.fns = fns
+        self.groups = groups
+        self.only_accepted = only_accepted
+        self.selector = selector
+        self.filters = []
+        self.filter_mode = filter_mode.upper()  # 'OR' (default) or 'AND'
+        # Get both API v1 and API v2 clients
+        self.clients = get_client()
+        self.papers = (
+            None  # this'll contain all the papers returned from apply_on_papers
+        )
 
-  def add_filter(self, filter_, *args, **kwargs):
-    self.filters.append((filter_, args, kwargs))
+    def __call__(self):
+        self.scrape()
+
+    def scrape(self):
+        print("Getting venues...")
+        venues = get_venues(self.clients, self.confs, self.years)
+        print("Getting papers...\n")
+        papers = get_papers(
+            self.clients, group_venues(venues, self.groups), self.only_accepted
+        )
+        self.papers = papers
+        print("\nFiltering papers...")
+        papers = self.apply_on_papers(papers)
+        if self.selector is not None:
+            papers_list = self.selector(papers)
+        else:
+            papers_list = papers_to_list(papers)
+        print("Saving as CSV...")
+        to_csv(papers_list, self.fpath)
+        print(f"Saved at {self.fpath}")
+
+    def apply_on_papers(self, papers):
+        modified_papers = {}
+        for group, grouped_venues in papers.items():
+            modified_papers[group] = {}
+            for venue, venue_papers in grouped_venues.items():
+                modified_papers[group][venue] = []
+                venue_split = venue.split("/")
+                venue_name, venue_year, venue_type = (
+                    venue_split[0],
+                    venue_split[1],
+                    venue_split[2],
+                )
+                for paper in venue_papers:
+                    # FILTERS
+                    if self.filter_mode == "AND":
+                        satisfying_keyword, satisfying_filter_type, satisfies = (
+                            satisfies_all_filters(paper, self.keywords, self.filters)
+                        )
+                    elif self.filter_mode == "MIX":
+                        satisfying_keyword, satisfying_filter_type, satisfies = (
+                            satisfies_mixed_filters(paper, self.keywords, self.filters)
+                        )
+                    else:
+                        satisfying_keyword, satisfying_filter_type, satisfies = (
+                            satisfies_any_filters(paper, self.keywords, self.filters)
+                        )
+                    if satisfies:
+                        paper.content["match"] = {
+                            str(satisfying_filter_type): satisfying_keyword
+                        }
+                        paper.content["group"] = group
+                        for fn in self.fns:
+                            paper = fn(paper)
+                        extracted_paper = self.extractor(paper)
+                        extracted_paper["venue"] = venue_name
+                        extracted_paper["year"] = venue_year
+                        extracted_paper["type"] = venue_type
+                        modified_papers[group][venue].append(extracted_paper)
+        return modified_papers
+
+    def add_filter(self, filter_, *args, **kwargs):
+        self.filters.append((filter_, args, kwargs))

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,11 @@ import openreview
 import csv
 from config import EMAIL, PASSWORD
 import dill
+import requests
+import re
+import html as html_lib
+from urllib.parse import unquote
+import os
 
 
 def get_client():
@@ -9,51 +14,183 @@ def get_client():
     Returns a tuple of (client_v1, client_v2) for both OpenReview API versions.
     """
     client_v1 = openreview.Client(
-        baseurl='https://api.openreview.net',
-        username=EMAIL,
-        password=PASSWORD
+        baseurl="https://api.openreview.net", username=EMAIL, password=PASSWORD
     )
-    
+
     client_v2 = openreview.api.OpenReviewClient(
-        baseurl='https://api2.openreview.net',
-        username=EMAIL,
-        password=PASSWORD
+        baseurl="https://api2.openreview.net", username=EMAIL, password=PASSWORD
     )
-    
+
     return client_v1, client_v2
 
 
 def papers_to_list(papers):
-  all_papers = []
-  for grouped_venues in papers.values():
-    for venue_papers in grouped_venues.values():
-      for paper in venue_papers:
-        all_papers.append(paper)
-  return all_papers
+    all_papers = []
+    for grouped_venues in papers.values():
+        for venue_papers in grouped_venues.values():
+            for paper in venue_papers:
+                all_papers.append(paper)
+    return all_papers
 
 
 def to_csv(papers_list, fpath):
-  def write_csv():
-    with open(fpath, 'a+') as fp:
-      fp.seek(0, 0) # seek to beginning of file and then read
-      previous_contents = fp.read()
-      writer = csv.DictWriter(fp, fieldnames=field_names)
-      if previous_contents.strip()=='':
-        writer.writeheader()
-      writer.writerows(papers_list)
-  if len(papers_list)>0:
-    field_names = list(papers_list[0].keys()) # choose one of the papers, get all the keys as they'll be same for rest of them
-    write_csv()
+    def write_csv():
+        with open(fpath, "a+") as fp:
+            fp.seek(0, 0)  # seek to beginning of file and then read
+            previous_contents = fp.read()
+            writer = csv.DictWriter(fp, fieldnames=field_names)
+            if previous_contents.strip() == "":
+                writer.writeheader()
+            writer.writerows(papers_list)
+
+    if len(papers_list) > 0:
+        field_names = list(
+            papers_list[0].keys()
+        )  # choose one of the papers, get all the keys as they'll be same for rest of them
+        write_csv()
 
 
 def save_papers(papers, fpath):
-  with open(fpath, 'wb') as fp:
-    dill.dump(papers, fp)
-    print(f'Papers saved at: {fpath}')
+    with open(fpath, "wb") as fp:
+        dill.dump(papers, fp)
+        print(f"Papers saved at: {fpath}")
 
 
 def load_papers(fpath):
-  with open(fpath, 'rb') as fp:
-    papers = dill.load(fp)
-  print(f'Papers loaded from: {fpath}')
-  return papers
+    with open(fpath, "rb") as fp:
+        papers = dill.load(fp)
+    print(f"Papers loaded from: {fpath}")
+    return papers
+
+
+def fetch_html(forum_id):
+    url = f"https://openreview.net/forum?id={forum_id}&format=bibtex"
+    try:
+        response = requests.get(url)
+        if response.status_code == 200:
+            return response.text.strip()
+        else:
+            print(f"Failed to fetch html for {forum_id}: {response.status_code}")
+            return ""
+    except Exception as e:
+        print(f"Error fetching html for {forum_id}: {e}")
+        return ""
+
+
+def fetch_bibtex_from_data_bibtex(forum_id):
+    """
+    Fetches and decodes the BibTeX entry from the `data-bibtex` attribute on the OpenReview forum page.
+    """
+    url = f"https://openreview.net/forum?id={forum_id}"
+    try:
+        response = requests.get(url)
+        if response.status_code != 200:
+            print(f"Failed to fetch HTML for {forum_id}: {response.status_code}")
+            return ""
+
+        html_text = response.text
+
+        # Find data-bibtex="..."
+        match = re.search(r'data-bibtex="([^"]+)"', html_text)
+        if not match:
+            print(f"No data-bibtex found in HTML for {forum_id}")
+            return ""
+
+        encoded_bibtex = match.group(1)
+        decoded_bibtex = unquote(encoded_bibtex)
+
+        return decoded_bibtex.strip()
+
+    except Exception as e:
+        print(f"Error fetching bibtex for {forum_id}: {e}")
+        return ""
+
+
+def build_bibtex_from_note(note, venue_name="OpenReview"):
+    """
+    Build a BibTeX entry from an OpenReview note object.
+    """
+    try:
+        import datetime
+
+        # Helper to extract value if wrapped in {"value": ...}
+        def extract_value(field):
+            if isinstance(field, dict) and "value" in field:
+                return field["value"]
+            return field
+
+        # Extract metadata with value-unpacking
+        authors_raw = note.content.get("authors", [])
+        authors = extract_value(authors_raw)
+        if isinstance(authors, list):
+            authors = [extract_value(a) for a in authors]
+        else:
+            authors = [str(authors)]
+        authors_str = " and ".join(authors)
+
+        title_raw = note.content.get("title", "No Title")
+        title = extract_value(title_raw).strip()
+
+        # Get publication year
+        if hasattr(note, "tcdate") and isinstance(note.tcdate, int):
+            year = datetime.datetime.fromtimestamp(note.tcdate / 1000).year
+        else:
+            year = "????"
+
+        # Construct OpenReview URL
+        url = f"https://openreview.net/forum?id={note.forum}"
+
+        # Create citation key: lastnameYEARkeyword
+        first_author_lastname = authors[0].split()[-1].lower() if authors else "anon"
+        title_words = [w for w in title.lower().split() if w.isalnum()]
+        suffix_word = title_words[0] if title_words else "paper"
+        key = f"{first_author_lastname}{year}{suffix_word}"
+
+        # Compose BibTeX entry
+        bibtex = f"""@inproceedings{{
+  {key},
+  title={{ {title} }},
+  author={{ {authors_str} }},
+  booktitle={{ {venue_name} }},
+  year={{ {year} }},
+  url={{ {url} }}
+}}"""
+        return bibtex
+
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+def download_pdf(pdf_url, dest_folder="pdfs", filename=None):
+    """
+    Downloads a PDF from the given URL to the specified folder.
+    If filename is not provided, it will use the last part of the URL.
+    Returns the path to the saved PDF.
+    """
+    if not os.path.exists(dest_folder):
+        os.makedirs(dest_folder)
+    if filename is None:
+        filename = pdf_url.split("/")[-1]
+    dest_path = os.path.join(dest_folder, filename)
+    try:
+        response = requests.get(pdf_url)
+        if response.status_code == 200:
+            with open(dest_path, "wb") as f:
+                f.write(response.content)
+            return dest_path
+        else:
+            print(f"Failed to download PDF: {pdf_url} (status {response.status_code})")
+            return None
+    except Exception as e:
+        print(f"Error downloading PDF {pdf_url}: {e}")
+        return None
+
+
+def unwrap_value(value):
+    """
+    Unwraps a value that may be wrapped in a {"value": ...} dict.
+    Recursively unwraps until the final value is returned.
+    """
+    if isinstance(value, dict) and "value" in value:
+        return value["value"]
+    return value


### PR DESCRIPTION
These changes introduce:
+ satisfies_all_filters: implements for a case that you need to retrieve papers that contain all desired keywords.
+ satisfies_mixed_filters: implements for a case that you need to retrieve papers that contain all groups of keywords, while each keyword group might be satisfied with only one of its forms; e.g. ["Large Language Model", "LLM"] (one satisfies the group).
+ Needed changes to the Scraper class, to allow for the integration of the above.

Minor bug fix:
+ Some papers do not contain "keywords" in their fields; this sometimes causes an error. This was fixed, in a safeguarded attribute retrieval; when the field is not present, an empty list is assumed instead.